### PR TITLE
modify TMCx web address, remove information about applications

### DIFF
--- a/source/_accelerators_and_incubators.md.erb
+++ b/source/_accelerators_and_incubators.md.erb
@@ -6,8 +6,8 @@ Energy Technology Accelerator. Located north of Montrose, also has coworking and
   "177 W. Gray St., Houston, TX 77019") %>
 
 
-### [TMCx](http://www.tmc-x.org/)
-Texas Medical Center's Healthcare Accelerator. All new program and campus as of Oct 2014. Applications are now open for their very first class.
+### [TMCx](http://www.tmcinnovation.org/tmc-x/)
+Texas Medical Center's Healthcare Accelerator. All new program and campus as of Oct 2014. 
 
 <%= resource_address_link(
   "Texas Medical Center John P. McGovern Campus",


### PR DESCRIPTION
- TMCx web address is now http://www.tmcinnovation.org/tmc-x/
- No longer accepting applications for first class
